### PR TITLE
Consider artillery with different ranks identical

### DIFF
--- a/injected_code.c
+++ b/injected_code.c
@@ -7489,7 +7489,7 @@ patch_Map_check_city_location (Map *this, int edx, int tile_x, int tile_y, int c
 bool
 is_zero_strength (UnitType * ut)
 {
-	return (ut->Attack == 0) && (ut->Defence == 0) && (ut->Bombard_Strength == 0) && (ut->Air_Defence == 0);
+	return (ut->Attack == 0) && (ut->Defence == 0);
 }
 
 bool


### PR DESCRIPTION
When grouping units, consider non-combat artillery units and flaks identical.

Note that there are "ranks" for these artillery units, and if they can bombard lethally, they even rank up. But I believe there's virtually no difference between a regular and an elite artillery. They don't bombard any better, and non-combat units do not produce Leaders. I've seen bombards result in Leaders, but only for combative artillery units (with A=1 D=6 for example.
