### PR TITLE
Bug fix: Keep generated resource tile state valid across recompute redraws

### DIFF
--- a/C3X.h
+++ b/C3X.h
@@ -934,7 +934,7 @@ const struct district_config special_district_defaults[USED_SPECIAL_DISTRICT_TYP
 		.buildable_square_types_mask = DEFAULT_DISTRICT_BUILDABLE_MASK,
 		.img_path_count = 5, .img_column_count = 4, .btn_tile_sheet_column = 0, .btn_tile_sheet_row = 0,
 		.culture_bonus = 1, .science_bonus = 1, .food_bonus = 0, .gold_bonus = 1, .shield_bonus = 0, .happiness_bonus = 0, .defense_bonus_percent = 25,
-		.generated_resource = NULL, .generated_resource_id = -1, .generated_resource_flags = 0
+		.generated_resource = NULL, .generated_resource_id = -1, .generated_resource_flags = 0, .auto_add_road = true
 
 	},
 	{

--- a/civ_prog_objects.csv
+++ b/civ_prog_objects.csv
@@ -493,7 +493,6 @@ inlead,	   0x5D2150,	0x5E13F0,	0x5D2080,	"Map_build_trade_network",			"void (__f
 inlead,	   0x57DE90,	0x58ABD0,	0x57DBF0,	"Trade_Net_recompute_city_cons_and_res", 	"void (__fastcall *) (Trade_Net * this, int edx, bool param_1)"
 repl call, 0x57DAF1,	0x58A7F9,	0x57D851,	"Trade_Net_set_unit_path_to_fill_road_net",	""
 repl call, 0x57DE29,	0x58AB4E,	0x57DB89,	"Trade_Net_set_unit_path_to_find_sea_route",	""
-define,	   0x5EA6E0,	0x5F9F30,	0x5EA610,	"Tile_has_colony",				"bool (__fastcall *) (Tile * this)"
 repl call, 0x5C1559,	0x5D00ED,	0x5C1269,	"City_count_airports_for_airdrop",		""
 define,	   0x437CF0,	0x4398A0,	0x437D70,	"Leader_get_city_count_on_continent",		"int (__fastcall *) (Leader * this, int edx, int cont_id)"
 repl call, 0x42EB3F,	0x430615,	0x42EBBF,	"Leader_get_cont_city_count_for_worker_req",	""

--- a/injected_code.c
+++ b/injected_code.c
@@ -15844,6 +15844,11 @@ compare_resource_tiles (void const * vp_a, void const * vp_b)
 void __fastcall
 patch_Trade_Net_recompute_resources (Trade_Net * this, int edx, bool skip_popups)
 {
+	if (is->saved_tile_count >= 0) {
+		(*p_OutputDebugStringA) ("[C3X] Skipping nested Trade_Net::recompute_resources call\n");
+		return;
+	}
+
 	int extra_resource_count = not_below (0, p_bic_data->ResourceTypeCount - 32);
 	int ints_per_city = 1 + extra_resource_count/32;
 	memset (is->extra_available_resources, 0, is->extra_available_resources_capacity * ints_per_city * sizeof (unsigned));
@@ -15936,16 +15941,31 @@ patch_Trade_Net_recompute_resources (Trade_Net * this, int edx, bool skip_popups
 Tile *
 get_resource_tile (int index)
 {
+	if ((index < 0) || (index >= is->count_resource_tiles)) {
+		is->got_resource_tile = NULL;
+		return p_null_tile;
+	}
+
 	struct extra_resource_tile * rt = &is->resource_tiles[index];
 	is->got_resource_tile = rt;
 	return rt->tile;
 }
 
-Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_1 (Map * map, int edx, int index) { return (index < is->saved_tile_count) ? Map_get_tile (map, __, index) : get_resource_tile (index - is->saved_tile_count); }
-Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_2 (Map * map, int edx, int index) { return (index < is->saved_tile_count) ? Map_get_tile (map, __, index) : get_resource_tile (index - is->saved_tile_count); }
-Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_3 (Map * map, int edx, int index) { return (index < is->saved_tile_count) ? Map_get_tile (map, __, index) : get_resource_tile (index - is->saved_tile_count); }
-Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_4 (Map * map, int edx, int index) { return (index < is->saved_tile_count) ? Map_get_tile (map, __, index) : get_resource_tile (index - is->saved_tile_count); }
-Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_5 (Map * map, int edx, int index) { return (index < is->saved_tile_count) ? Map_get_tile (map, __, index) : get_resource_tile (index - is->saved_tile_count); }
+Tile *
+get_tile_when_recomputing_resources (Map * map, int index)
+{
+	if ((is->saved_tile_count < 0) || (index < is->saved_tile_count)) {
+		is->got_resource_tile = NULL;
+		return Map_get_tile (map, __, index);
+	}
+	return get_resource_tile (index - is->saved_tile_count);
+}
+
+Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_1 (Map * map, int edx, int index) { return get_tile_when_recomputing_resources (map, index); }
+Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_2 (Map * map, int edx, int index) { return get_tile_when_recomputing_resources (map, index); }
+Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_3 (Map * map, int edx, int index) { return get_tile_when_recomputing_resources (map, index); }
+Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_4 (Map * map, int edx, int index) { return get_tile_when_recomputing_resources (map, index); }
+Tile * __fastcall patch_Map_get_tile_when_recomputing_resources_5 (Map * map, int edx, int index) { return get_tile_when_recomputing_resources (map, index); }
 
 int __fastcall
 patch_Tile_get_visible_resource_when_recomputing (Tile * tile, int edx, int civ_id)
@@ -24927,7 +24947,6 @@ patch_Map_Renderer_m71_Draw_Tiles (Map_Renderer * this, int edx, int param_1, in
 	// Restore the tile count if it was saved by recompute_resources. This is necessary because the Draw_Tiles method loops over all tiles.
 	if (is->saved_tile_count >= 0) {
 		p_bic_data->Map.TileCount = is->saved_tile_count;
-		is->saved_tile_count = -1;
 	}
 
 	Map_Renderer_m71_Draw_Tiles (this, __, param_1, param_2, param_3);
@@ -34787,7 +34806,6 @@ patch_Unit_ai_move_terraformer (Unit * this)
 	bool is_human = (*p_human_player_bits & (1 << this->Body.CivID)) != 0;
 	int territory_owner = ((tile != NULL) && (tile != p_null_tile)) ? tile->vtable->m38_Get_Territory_OwnerID (tile) : -1;
 
-	
 	if (is->current_config.enable_districts && ! is_human && is_worker (this)) {
 		update_tracked_worker_for_unit (this);
 		struct district_instance * inst = get_district_instance (tile);

--- a/injected_code.c
+++ b/injected_code.c
@@ -24947,6 +24947,7 @@ patch_Map_Renderer_m71_Draw_Tiles (Map_Renderer * this, int edx, int param_1, in
 	// Restore the tile count if it was saved by recompute_resources. This is necessary because the Draw_Tiles method loops over all tiles.
 	if (is->saved_tile_count >= 0) {
 		p_bic_data->Map.TileCount = is->saved_tile_count;
+		is->saved_tile_count = -1;
 	}
 
 	Map_Renderer_m71_Draw_Tiles (this, __, param_1, param_2, param_3);


### PR DESCRIPTION
This is a fix for som_rybov's bug report, [here](https://forums.civfanatics.com/threads/c3x-exe-mod-including-bug-fixes-stack-bombard-and-much-more.666881/post-16953043), save attached.

In a nutshell, I traced the crash back to `Tile_has_colony` getting a NULL tile. However patching that (bailing if NULL) fixed the symptom but not the underlying problem. 

As best I can tell, the crash is from `Trade_Net::recompute_resources` receiving a bad tile pointer while we have the temporarily expanded Map.TileCount to include generated resource tiles.

1. `patch_Trade_Net_recompute_resources builds` is->resource_tiles.
2. It saves the real tile count:
```c
is->saved_tile_count = p_bic_data->Map.TileCount;
p_bic_data->Map.TileCount += is->count_resource_tiles;
```
3. `Trade_Net::recompute_resources` loops over 0 .. Map.TileCount - 1.
4. The patched `Map_get_tile_when_recomputing_resources_*` functions are supposed to return:
  - real map tile if index < saved_tile_count
  - generated resource tile otherwise
5. But `Tile::has_colony(NULL)` means (I think) the first tile lookup returned NULL.

So if a resource recompute happens while saved_tile_count is already active, then saved_tile_count can be overwritten with an already-inflated tile count. Then an artificial tile index is misclassified as a real map index, so the wrapper calls real Map_get_tile with an out-of-range index. That returns NULL.

The saved game moves to the next turn after these changes, and calculated resources appear correct afterward.

Also: I noticed in the course of debugging this we had duplicate `define Tile_has_colony` entries in civ_prog_objects.csv and removed the 2nd one.

PS - holy moly, the repo is really heating up with PRs. I hope all is well and this isn't all too much too quickly.

[bug.zip](https://github.com/user-attachments/files/28231512/bug.zip)
