### PR TITLE
Fix named tile load procedure to advance by serialized field size

### DIFF
--- a/injected_code.c
+++ b/injected_code.c
@@ -34378,10 +34378,10 @@ patch_move_game_data (byte * buffer, bool save_else_load)
 							remaining_bytes -= (int)sizeof(int) * 2;
 
 							char name_buf[101];
-							memcpy (name_buf, cursor, sizeof name_buf);
+							memcpy (name_buf, cursor, sizeof ((struct named_tile_entry *)0)->name);
 							name_buf[(sizeof name_buf) - 1] = '\0';
-							cursor += sizeof name_buf;
-							remaining_bytes -= sizeof name_buf;
+							cursor += sizeof ((struct named_tile_entry *)0)->name;
+							remaining_bytes -= sizeof ((struct named_tile_entry *)0)->name;
 							ints = (int *)cursor;
 
 							if (name_buf[0] == '\0')


### PR DESCRIPTION
Sorry for so many (mostly small, luckily) PRs lately. I've finally had a chance to really put the features I've added over the past year through their paces and found minor bugs here and there. Here's one:

<img width="500" alt="Screenshot 2026-07-17 at 7 35 51 PM" src="https://github.com/user-attachments/assets/2ddc40e7-7d0f-4151-a1b8-31bc096c5714" />

The loading process throws an error if there is more than one named tile. You can recreate this by just starting a new game, naming a couple tiles, saving, and trying to load.

The issue is that the save write procedure was storing each name as 100 bytes, but advancing by 101 bytes from using `name_buf[101]`. 