### PR TITLE
Ensure tradenet recalcs due to auto-adding roads/rails always see true tile count

### DIFF
--- a/injected_code.c
+++ b/injected_code.c
@@ -6786,6 +6786,22 @@ pick_missing_district_for_improvement (City * city, struct district_building_pre
 	return fallback;
 }
 
+void
+district_set_tile_flags_safely (Tile * tile, int layer, int flags, int tile_x, int tile_y)
+{
+	int restore_tile_count = -1;
+
+	if ((is->saved_tile_count >= 0) &&
+	    (p_bic_data->Map.TileCount != is->saved_tile_count)) {
+		restore_tile_count = p_bic_data->Map.TileCount;
+		p_bic_data->Map.TileCount = is->saved_tile_count;
+	}
+
+	tile->vtable->m56_Set_Tile_Flags (tile, __, layer, flags, tile_x, tile_y);
+
+	if ((restore_tile_count >= 0) && (is->saved_tile_count >= 0))
+		p_bic_data->Map.TileCount = restore_tile_count;
+}
 
 bool
 district_is_complete(Tile * tile, int district_id)
@@ -6857,14 +6873,14 @@ district_is_complete(Tile * tile, int district_id)
 		if (cfg->auto_add_road) {
 			bool has_road = tile->vtable->m25_Check_Roads (tile, __, 0) != 0;
 			if (! has_road)
-				tile->vtable->m56_Set_Tile_Flags (tile, __, 0, TILE_FLAG_ROAD, tile_x, tile_y); 
+				district_set_tile_flags_safely (tile, 0, TILE_FLAG_ROAD, tile_x, tile_y);
 		}
 
 		if (cfg->auto_add_railroad) {
 			bool has_railroad = tile->vtable->m23_Check_Railroads (tile, __, 0) != 0;
 			if (! has_railroad) {
 				if ((territory_owner >= 0) && patch_Leader_can_do_worker_job (&leaders[territory_owner], __, WJ_Build_Railroad, tile_x, tile_y, 0)) {
-					tile->vtable->m56_Set_Tile_Flags (tile, __, 0, TILE_FLAG_RAILROAD, tile_x, tile_y); 
+					district_set_tile_flags_safely (tile, 0, TILE_FLAG_RAILROAD, tile_x, tile_y);
 				}
 			}
 		}

--- a/injected_code.c
+++ b/injected_code.c
@@ -6786,23 +6786,6 @@ pick_missing_district_for_improvement (City * city, struct district_building_pre
 	return fallback;
 }
 
-void
-district_set_tile_flags_safely (Tile * tile, int layer, int flags, int tile_x, int tile_y)
-{
-	int restore_tile_count = -1;
-
-	if ((is->saved_tile_count >= 0) &&
-	    (p_bic_data->Map.TileCount != is->saved_tile_count)) {
-		restore_tile_count = p_bic_data->Map.TileCount;
-		p_bic_data->Map.TileCount = is->saved_tile_count;
-	}
-
-	tile->vtable->m56_Set_Tile_Flags (tile, __, layer, flags, tile_x, tile_y);
-
-	if ((restore_tile_count >= 0) && (is->saved_tile_count >= 0))
-		p_bic_data->Map.TileCount = restore_tile_count;
-}
-
 bool
 district_is_complete(Tile * tile, int district_id)
 {
@@ -6846,6 +6829,11 @@ district_is_complete(Tile * tile, int district_id)
 		return false;
 	}
 
+	// Defer setting complete flag until after Trade Net recomputation is done, as auto-adding 
+	// roads/railroads may trigger Trade Net updates that in turn depends on the non-artificial tile count being present
+	if (is->saved_tile_count >= 0)
+		return false;
+
 	// Mark as completed and run one-time side effects
 	inst->state = DS_COMPLETED;
 	inst->completed_turn = *p_current_turn_no;
@@ -6873,14 +6861,14 @@ district_is_complete(Tile * tile, int district_id)
 		if (cfg->auto_add_road) {
 			bool has_road = tile->vtable->m25_Check_Roads (tile, __, 0) != 0;
 			if (! has_road)
-				district_set_tile_flags_safely (tile, 0, TILE_FLAG_ROAD, tile_x, tile_y);
+				tile->vtable->m56_Set_Tile_Flags (tile, __, 0, TILE_FLAG_ROAD, tile_x, tile_y);
 		}
 
 		if (cfg->auto_add_railroad) {
 			bool has_railroad = tile->vtable->m23_Check_Railroads (tile, __, 0) != 0;
 			if (! has_railroad) {
 				if ((territory_owner >= 0) && patch_Leader_can_do_worker_job (&leaders[territory_owner], __, WJ_Build_Railroad, tile_x, tile_y, 0)) {
-					district_set_tile_flags_safely (tile, 0, TILE_FLAG_RAILROAD, tile_x, tile_y);
+					tile->vtable->m56_Set_Tile_Flags (tile, __, 0, TILE_FLAG_RAILROAD, tile_x, tile_y);
 				}
 			}
 		}


### PR DESCRIPTION
Another bug fix. I thought I had slain the monster caused by auto-adding roads when the tile count was artificially inflated, but it rose again. I have a deterministic save that crashes in the interturn each time that I'm happy to provide to test with, if you'd like (with [my scenario](https://forums.civfanatics.com/threads/instafluffs-scenario.703788/) though, so you'd need that too).

The solution I settled on is just to replace the direct `tile->vtable->m56_Set_Tile_Flags` call with a small wrapper function, `district_set_tile_flags_safely`, that ensures that when Trade Net side effects are run due to road/rail additions, the true tile count is always the one present.

If you want me to rename the function just let me know, or feel free to.


