### PR TITLE
Ensure if governor is on, worked tiles & specialties are optimized after district yields are added in

### DIFF
--- a/injected_code.c
+++ b/injected_code.c
@@ -223,6 +223,7 @@ int __cdecl patch_get_building_defense_bonus_at (int x, int y, int param_3);
 
 // Declare various functions needed for districts and hard to untangle and reorder here
 void __fastcall patch_City_recompute_yields_and_happiness (City * this);
+void __fastcall patch_City_manage_by_governor (City * this, int edx, bool manage_professions);
 void __fastcall patch_Map_build_trade_network (Map * this);
 bool __fastcall patch_Unit_can_perform_command (Unit * this, int edx, int unit_command_value);
 bool __fastcall patch_Unit_can_pillage (Unit * this, int edx, int tile_x, int tile_y);
@@ -6984,8 +6985,8 @@ set_tile_unworkable_for_all_cities (Tile * tile, int tile_x, int tile_y)
 			removed_assignment = City_stop_working_tile (assigned_city, __, neighbor_index);
 		if (! removed_assignment)
 			tile->Body.CityAreaID = -1;
-		if (! removed_assignment)
-			recompute_city_yields_with_districts (assigned_city);
+		recompute_city_yields_with_districts (assigned_city);
+		patch_City_manage_by_governor (assigned_city, __, false);
 	} else
 		tile->Body.CityAreaID = -1;
 
@@ -7002,6 +7003,7 @@ set_tile_unworkable_for_all_cities (Tile * tile, int tile_x, int tile_y)
 			if ((work_radius < 0) || (work_radius > is->current_config.city_work_radius))
 				continue;
 			recompute_city_yields_with_districts (city);
+			patch_City_manage_by_governor (city, __, false);
 		}
 	}
 }
@@ -7339,8 +7341,10 @@ remove_distribution_hub_record (Tile * tile)
 	if ((affected_civ_id >= 0) && (p_cities->Cities != NULL)) {
 			for (int city_index = 0; city_index <= p_cities->LastIndex; city_index++) {
 				City * target_city = get_city_ptr (city_index);
-				if ((target_city != NULL) && (target_city->Body.CivID == affected_civ_id))
+				if ((target_city != NULL) && (target_city->Body.CivID == affected_civ_id)) {
 					recompute_city_yields_with_districts (target_city);
+					patch_City_manage_by_governor (target_city, __, false);
+				}
 			}
 	}
 }
@@ -7469,8 +7473,10 @@ recompute_distribution_hub_totals ()
 		if (civs_needing_recalc[civ_id] && (p_cities->Cities != NULL)) {
 			for (int city_index = 0; city_index <= p_cities->LastIndex; city_index++) {
 				City * city = get_city_ptr (city_index);
-				if ((city != NULL) && (city->Body.CivID == civ_id))
+				if ((city != NULL) && (city->Body.CivID == civ_id)) {
 					recompute_city_yields_with_districts (city);
+					patch_City_manage_by_governor (city, __, false);
+				}
 			}
 		}
 	}
@@ -7504,8 +7510,10 @@ on_distribution_hub_completed (Tile * tile, int tile_x, int tile_y)
 			// Recompute for old civ
 			for (int city_index = 0; city_index <= p_cities->LastIndex; city_index++) {
 				City * target_city = get_city_ptr (city_index);
-				if ((target_city != NULL) && (target_city->Body.CivID == old_civ_id))
+				if ((target_city != NULL) && (target_city->Body.CivID == old_civ_id)) {
 					recompute_city_yields_with_districts (target_city);
+					patch_City_manage_by_governor (target_city, __, false);
+				}
 			}
 		}
 	}
@@ -7532,8 +7540,10 @@ on_distribution_hub_completed (Tile * tile, int tile_x, int tile_y)
 	if ((affected_civ_id >= 0) && (p_cities->Cities != NULL)) {
 		for (int city_index = 0; city_index <= p_cities->LastIndex; city_index++) {
 			City * target_city = get_city_ptr (city_index);
-			if ((target_city != NULL) && (target_city->Body.CivID == affected_civ_id))
+			if ((target_city != NULL) && (target_city->Body.CivID == affected_civ_id)) {
 				recompute_city_yields_with_districts (target_city);
+				patch_City_manage_by_governor (target_city, __, false);
+			}
 		}
 	}
 }
@@ -26996,10 +27006,6 @@ auto_build_great_wall_districts_for_civ (int civ_id)
 
 	is->focused_tile = NULL;
 }
-
-//We need to forwards-declare this
-void __fastcall
-patch_City_manage_by_governor (City * this, int edx, bool manage_professions);
 
 void __fastcall
 patch_City_add_or_remove_improvement (City * this, int edx, int improv_id, int add, bool param_3)


### PR DESCRIPTION
In cases where city governors are managing tiles/specialists, district & distro hub benefits can be recalculated/redistributed in the interturn (for example, reducing food) and the governor management function isn't automatically run afterward. The result is that often at the start of turns, a city with a governor active can appear to be starving, etc., and the user needs to manually open the city view, open the governor window then close it, in order for the governor management process to be run with district/distro hub yields factored in.

The changes here just ensure that whenever district/distro hubs yields are recalculated for a city, we run the governor process (if activated; I'm lazy so always leave gov. on) afterward to avoid needing the user to manually run this for each city.