### PR TITLE
Fix crash (0xC0000005) when a NULL city pointer is passed to City_has_improvement

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 - Fix some ways areas revealed by recon can stay permanently revealed
   - Can happen when the unit that performed recon was destroyed before the start of its next turn (this is a base game bug)
   - Can happen when a unit has performed multiple recon missions in one turn (possible if charge_one_move_for_recon_and_interception option is active)
+- Fix crash (0xC0000005) when a NULL city pointer is passed to City_has_improvement
 
 * RELEASE 28 PREVIEW 1
 - Allow for custom combat bonuses or maluses to be applied based on unit type, combat role (attack, defense, or bombard), terrain, city/district, and experience level

--- a/injected_code.c
+++ b/injected_code.c
@@ -16288,6 +16288,9 @@ show_map_specific_text (int tile_x, int tile_y, char const * text, bool pause)
 bool __fastcall
 patch_City_has_improvement (City * this, int edx, int improv_id, bool include_auto_improvements)
 {
+	if (this == NULL)
+		return false;
+
 	bool tr = City_has_improvement (this, __, improv_id, include_auto_improvements);
 
 	// Check if the improvement is provided for free by another human player's wonder if we're in a hotseat game and the config option is on


### PR DESCRIPTION
Fixes a recurring `0xC0000005` crash (EIP `0x000002DF`, a virtual call through a NULL vtable) triggered when `patch_City_has_improvement()` is invoked with a NULL `City*`.

## Root cause
`patch_City_has_improvement()` unconditionally forwarded to the game's virtual `City_has_improvement()`. With a NULL `this`, the vtable dispatch executed `call [NULL + 0x2DF]`, faulting on the read at `0x2DF`.

Confirmed by disassembling the faulting wrapper in a full crash dump: the instruction sequence at the wrapper entry matched this function exactly (the `share_wonders_in_hotseat` branch, the `this->Body.CivID` reads, the `p_human_player_bits` mask, and the player-bits loop all line up instruction-for-instruction).

## Fix
Added a guard at the top of the function returning `false`:

```c
if (this == NULL)
    return false;
```

This is safe because all call sites consume the return value only in boolean context, and the code already NULL-guards this exact call elsewhere:

```c
if ((city == NULL) || (! patch_City_has_improvement (city, __, wonder_improv_id, false)))
```

## Notes
- Not config-dependent (reproduces with all-default config).
- Verified the compiled guard is present in the patched `.c3xtxt` section, and that `injected_code.c` compiles cleanly via the repo's `TEST_INJECTED_CODE_COMPILE.bat`.
- Changelog entry added.
